### PR TITLE
ダイソーのシャッターリモコンで動作しない不具合の修正

### DIFF
--- a/iOS/Panorama360_MatterportAxis/Panorama360_MatterportAxis/ViewController.swift
+++ b/iOS/Panorama360_MatterportAxis/Panorama360_MatterportAxis/ViewController.swift
@@ -33,7 +33,7 @@ class ViewController: UIViewController ,MatterportAxisManagerDelegate ,CameraCap
         super.viewDidLoad()
         mMatterportAxisManager = MatterportAxisManager(delegate: self)
         mCameraCapture = CameraCapture(view: imgCameraPreview,delegate: self)
-        mCameraCapture.startListeningVolumeButton(view: self.view)
+        mCameraCapture.startListeningVolumeButton()
         UIApplication.shared.isIdleTimerDisabled = true
         if let soundStartURL = Bundle.main.url(forResource: "start", withExtension: "mp3") {
             do {
@@ -49,11 +49,14 @@ class ViewController: UIViewController ,MatterportAxisManagerDelegate ,CameraCap
                 print("Sound Loading error")
             }
         }
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        mCameraCapture.setInitalVolume()
+
+        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main) { notify in
+            self.mCameraCapture.setInitalVolume()
+        }
+        
+        NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: .main) { notify in
+            self.mCameraCapture.stopListeningVolume()
+        }
     }
 
     @IBAction func pushConnect(_ sender: UIButton) {


### PR DESCRIPTION
9ca149a0a32f1ac5c308ff6a1c778c3685eb0ae6 だけだと不完全だった

バックグラウンドから復帰したときに
`AVAudioSession.sharedInstance().setActive(true)`をやり直さないと、音量変化がちゃんと取れないみたい？