### PR TITLE
[iOS] Fixed crash when switching camera on iPhone SE

### DIFF
--- a/iOS/Panorama360_MatterportAxis/Panorama360_MatterportAxis/CameraCapture.swift
+++ b/iOS/Panorama360_MatterportAxis/Panorama360_MatterportAxis/CameraCapture.swift
@@ -100,6 +100,10 @@ extension CameraCapture {
         setFocus(position: 0.8)
     }
 
+    func isUltraWideCameraUsable() -> Bool {
+        mUltraWideCamera != nil
+    }
+
     func changeCamera(type: CameraType, focus: Float) {
         let oldDeviceInput = mCaptureSession.inputs[0]
 

--- a/iOS/Panorama360_MatterportAxis/Panorama360_MatterportAxis/model/ContentViewModel.swift
+++ b/iOS/Panorama360_MatterportAxis/Panorama360_MatterportAxis/model/ContentViewModel.swift
@@ -35,6 +35,7 @@ class ContentViewModel: ObservableObject {
     @Published var mExposureBracketMode = 3
     @Published var mCameraType: CameraType = .normal
     @Published var isCapture = false
+    @Published var isUltraWideCamera = false
 
     // Sound
     private var mStartSound: AVAudioPlayer!
@@ -44,6 +45,9 @@ class ContentViewModel: ObservableObject {
         if !isPreview {
             mCameraCapture = CameraCapture(view: mPreviewView, delegate: self)
             mCameraCapture?.initVolumeView()
+            if let cameraCapture = mCameraCapture {
+                isUltraWideCamera = cameraCapture.isUltraWideCameraUsable()
+            }
             mMatterportAxisManager = MatterportAxisManager(delegate: self)
 
             if let soundStartURL = Bundle.main.url(forResource: "start", withExtension: "mp3") {
@@ -111,6 +115,10 @@ class ContentViewModel: ObservableObject {
     }
 
     func changeLens() {
+        guard isUltraWideCamera else {
+            showToast(msg: "お使いの端末には超広角レンズが搭載されていません。")
+            return
+        }
         mCameraType = mCameraType == .normal ? CameraType.wide : CameraType.normal
 
         if mCameraType == .normal {


### PR DESCRIPTION
iPhone SEなどのカメラが一つしかない端末でカメラ切り替えを行うとクラッシュする不具合の修正